### PR TITLE
Fix HA 2026.7 NoneType create_task regression

### DIFF
--- a/custom_components/energytariff/sensor.py
+++ b/custom_components/energytariff/sensor.py
@@ -281,6 +281,11 @@ class GridCapWatcherEstimatedEnergySensor(SensorEntity):
             )
         )
 
+        self._disposables = []
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
         self._disposables = [
             self._coordinator.effectstate.subscribe(self._state_change)
         ]

--- a/custom_components/energytariff/sensor.py
+++ b/custom_components/energytariff/sensor.py
@@ -672,10 +672,9 @@ class GridCapWatcherAvailableEffectRemainingHour(RestoreSensor):
             )
         )
 
-        self._disposables = [
-            self._coordinator.thresholddata.subscribe(self._threshold_state_change),
-            self._coordinator.effectstate.subscribe(self._effect_state_change),
-        ]
+        # Subscribe after entity is attached to hass to avoid callback-triggered
+        # schedule_update_ha_state calls while self.hass is still None.
+        self._disposables = []
 
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
@@ -705,6 +704,11 @@ class GridCapWatcherAvailableEffectRemainingHour(RestoreSensor):
 
         if savedstate:
             self.__calculate()
+
+        self._disposables = [
+            self._coordinator.thresholddata.subscribe(self._threshold_state_change),
+            self._coordinator.effectstate.subscribe(self._effect_state_change),
+        ]
 
     async def async_will_remove_from_hass(self) -> None:
         for d in self._disposables:
@@ -845,9 +849,7 @@ class GridCapacityWatcherCurrentLevelName(RestoreSensor):
         self._state = None
         self._attr_unique_id = f"{DOMAIN}_effect_level_name".replace("sensor.", "")
 
-        self._disposables = [
-            self._coordinator.thresholddata.subscribe(self._threshold_state_change)
-        ]
+        self._disposables = []
 
     def _threshold_state_change(self, state: GridThresholdData):
         if state is None:
@@ -862,6 +864,9 @@ class GridCapacityWatcherCurrentLevelName(RestoreSensor):
         if savedstate:
             if savedstate.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._state = savedstate.state
+        self._disposables = [
+            self._coordinator.thresholddata.subscribe(self._threshold_state_change)
+        ]
 
     async def async_will_remove_from_hass(self) -> None:
         for d in self._disposables:
@@ -912,9 +917,7 @@ class GridCapacityWatcherCurrentLevelPrice(RestoreSensor):
         self._state = None
         self._attr_unique_id = f"{DOMAIN}_effect_level_price".replace("sensor.", "")
 
-        self._disposables = [
-            self._coordinator.thresholddata.subscribe(self._threshold_state_change)
-        ]
+        self._disposables = []
 
     def _threshold_state_change(self, state: GridThresholdData):
         if state is None:
@@ -929,6 +932,9 @@ class GridCapacityWatcherCurrentLevelPrice(RestoreSensor):
         if savedstate:
             if savedstate.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._state = savedstate.state
+        self._disposables = [
+            self._coordinator.thresholddata.subscribe(self._threshold_state_change)
+        ]
 
     async def async_will_remove_from_hass(self) -> None:
         for d in self._disposables:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -422,6 +422,29 @@ async def test_level_name_sensor_threshold_change(hass, config_with_levels, mock
 
 
 @pytest.mark.asyncio
+async def test_level_name_subscribes_only_after_added_to_hass(
+    hass, config_with_levels, mock_coordinator
+):
+    """Regression #47: pre-add threshold emissions must not schedule HA updates."""
+    sensor = GridCapacityWatcherCurrentLevelName(
+        hass, config_with_levels, mock_coordinator
+    )
+    sensor.schedule_update_ha_state = Mock()
+
+    mock_coordinator.thresholddata.on_next(GridThresholdData("Low", 2.0, 50, []))
+    assert sensor._state is None
+    assert not sensor.schedule_update_ha_state.called
+
+    sensor.async_get_last_state = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    sensor.schedule_update_ha_state.reset_mock()
+    mock_coordinator.thresholddata.on_next(GridThresholdData("High", 8.0, 200, []))
+    assert sensor._state == "High"
+    assert sensor.schedule_update_ha_state.called
+
+
+@pytest.mark.asyncio
 async def test_level_price_sensor_initialization(hass, config_with_levels, mock_coordinator):
     """Test GridCapacityWatcherCurrentLevelPrice initialization."""
     sensor = GridCapacityWatcherCurrentLevelPrice(
@@ -445,6 +468,29 @@ async def test_level_price_sensor_threshold_change(hass, config_with_levels, moc
     sensor._threshold_state_change(threshold_data)
     
     assert sensor._state == 200
+    assert sensor.schedule_update_ha_state.called
+
+
+@pytest.mark.asyncio
+async def test_level_price_subscribes_only_after_added_to_hass(
+    hass, config_with_levels, mock_coordinator
+):
+    """Regression #47: pre-add threshold emissions must not schedule HA updates."""
+    sensor = GridCapacityWatcherCurrentLevelPrice(
+        hass, config_with_levels, mock_coordinator
+    )
+    sensor.schedule_update_ha_state = Mock()
+
+    mock_coordinator.thresholddata.on_next(GridThresholdData("Low", 2.0, 50, []))
+    assert sensor._state is None
+    assert not sensor.schedule_update_ha_state.called
+
+    sensor.async_get_last_state = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    sensor.schedule_update_ha_state.reset_mock()
+    mock_coordinator.thresholddata.on_next(GridThresholdData("Medium", 5.0, 100, []))
+    assert sensor._state == 100
     assert sensor.schedule_update_ha_state.called
 
 
@@ -1344,6 +1390,30 @@ async def test_available_effect_sensor_float_target_no_template_tracking(hass, m
 
 
 @pytest.mark.asyncio
+async def test_available_effect_subscribes_only_after_added_to_hass(hass, mock_coordinator):
+    """Regression #47: pre-add coordinator emissions must not schedule HA updates."""
+    config = {
+        CONF_EFFECT_ENTITY: "sensor.power_meter",
+        TARGET_ENERGY: 10.0,
+        ROUNDING_PRECISION: 2,
+    }
+    sensor = GridCapWatcherAvailableEffectRemainingHour(hass, config, mock_coordinator)
+    sensor.schedule_update_ha_state = Mock()
+
+    mock_coordinator.effectstate.on_next(EnergyData(2.0, 1000.0, dt.now()))
+    assert sensor._state is None
+    assert not sensor.schedule_update_ha_state.called
+
+    sensor.async_get_last_state = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    sensor.schedule_update_ha_state.reset_mock()
+    mock_coordinator.effectstate.on_next(EnergyData(2.0, 1000.0, dt.now()))
+    assert sensor._state is not None
+    assert sensor.schedule_update_ha_state.called
+
+
+@pytest.mark.asyncio
 async def test_available_effect_template_target_result_change(hass, mock_coordinator):
     """When the template result changes, _target_energy is updated and calculation runs."""
     tmpl = template_helper.Template(_TARIFF_TEMPLATE, hass)
@@ -1541,4 +1611,3 @@ async def test_available_effect_template_target_ha_state_change_integration(hass
     )
     assert sensor.attr["grid_threshold_level"] == pytest.approx(8.0)
     assert sensor._state is not None
-

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -255,6 +255,26 @@ async def test_estimated_energy_sensor_state_change(hass, basic_config, mock_coo
 
 
 @pytest.mark.asyncio
+async def test_estimated_energy_subscribes_only_after_added_to_hass(
+    hass, basic_config, mock_coordinator
+):
+    """Regression #47: estimated sensor must ignore pre-add coordinator emissions."""
+    sensor = GridCapWatcherEstimatedEnergySensor(hass, basic_config, mock_coordinator)
+    sensor.schedule_update_ha_state = Mock()
+
+    mock_coordinator.effectstate.on_next(EnergyData(2.0, 1000.0, dt.now()))
+    assert sensor._state is None
+    assert not sensor.schedule_update_ha_state.called
+
+    await sensor.async_added_to_hass()
+
+    sensor.schedule_update_ha_state.reset_mock()
+    mock_coordinator.effectstate.on_next(EnergyData(2.0, 1000.0, dt.now()))
+    assert sensor._state is not None
+    assert sensor.schedule_update_ha_state.called
+
+
+@pytest.mark.asyncio
 async def test_average_peak_hours_initialization(hass, basic_config, mock_coordinator):
     """Test GridCapWatcherAverageThreePeakHours initialization."""
     sensor = GridCapWatcherAverageThreePeakHours(hass, basic_config, mock_coordinator)


### PR DESCRIPTION
## Summary
- move vulnerable rx subscriptions from `__init__` to `async_added_to_hass` for:
  - `GridCapWatcherAvailableEffectRemainingHour`
  - `GridCapacityWatcherCurrentLevelName`
  - `GridCapacityWatcherCurrentLevelPrice`
- keep disposable cleanup unchanged in `async_will_remove_from_hass`
- add regression tests proving pre-add coordinator emissions do not schedule HA updates

## Validation
- `pytest tests/test_sensor.py -v`

Closes #47